### PR TITLE
fix bug that requires a separate port for websockets

### DIFF
--- a/chessence-backend/backend_with_db.js
+++ b/chessence-backend/backend_with_db.js
@@ -12,7 +12,7 @@ import { createServer } from "http";
 import { Chess } from "chess.js";
 
 const app = express();
-const server = createServer();
+const server = createServer(app);
 const io = new Server(server, {
     cors: {
         origin: process.env.CORS_ORIGIN,
@@ -23,7 +23,6 @@ const port = 8000;
 dotenv.config();
 
 /** websocket code **/
-io.listen(4000); // use this port for ws connections
 // rooms is a dict of roomId : { white: id || undef, black: id || undef, chess: Chess }
 const rooms = {};
 const joinRoom = (socketId, roomId, time) => {
@@ -222,6 +221,6 @@ app.delete("/history/:id", async (req, res) => {
     }
 });
 
-app.listen(process.env.PORT || port, () => {
+server.listen(process.env.PORT || port, () => {
     console.log("REST API is listening.");
 });

--- a/chessence-frontend/.env-sample
+++ b/chessence-frontend/.env-sample
@@ -1,2 +1,1 @@
 REACT_APP_BACKEND=where the rest API endpoint is, e.g. http://localhost:8000
-REACT_APP_BACKEND_SOCKET=where the socket endpoint is, e.g. http://localhost:4000

--- a/chessence-frontend/src/api/socket.js
+++ b/chessence-frontend/src/api/socket.js
@@ -2,7 +2,7 @@ import { io } from "socket.io-client";
 
 // setting URL to "undefined" means the URL
 // will be computed from the `window.location` object
-const URL = process.env.REACT_APP_BACKEND_SOCKET;
+const URL = process.env.REACT_APP_BACKEND;
 
 // connects to socket
 export const socket = io(URL);


### PR DESCRIPTION
turns out you don't need a separate port, I just forgot to pass in the express app to the server function.